### PR TITLE
Feature/show expected fields

### DIFF
--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -109,7 +109,7 @@ class CsvModel(object):
             return self.dict_error
 
         msg = _("the head field '%s' not do match")
-        self.dict_error = {i: (msg % i) for i in self.mapping.keys()}
+        self.dict_error = {i: (msg % i) for i in self.get_user_visible_fields()}
         return self.dict_error
 
 

--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -42,6 +42,10 @@ class CsvModel(object):
                 not self.Meta.create_model
 
     def get_user_visible_fields(self):
+        # extra fields is used to capture the names of the columns used in the pre_save and
+        # post_save methods each csvmodel. Is neccesary define in every Meta of csvmodel one list
+        # of this names if is used in pre_save or post_save
+        # This method get_user_visible_fields is used for validated the header of the file
         head = self.extra_fields.copy()
         for f in self.mapping.keys():
             field = self.fields[f]


### PR DESCRIPTION
documentation why we need extra_fields and how used in get_user_visible_fields method of CsvModel
fixed bug get_dict_error. Now this use get_user_visible_fields instead of get_mapping

The correct process for merge to feature/use-djimporter is start with:
1.- merge  https://github.com/ico-apps/django-importer/pull/8
2.- merge  https://github.com/ico-apps/monitoring/pull/117
3.- merge  https://github.com/ico-apps/monitoring/pull/118

This branch is strong depending of header_fields of monitoring. Because in there is defined the extra_fields in the csvmodels.py.
When merge to master need merge header_fields in monitoring too.