### PR TITLE
Custom importlog model

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ INSTALLED_APPS = [
     'djimporter',
 ]
 ```
+
+## Configuration
+django-importer supports using a custom model for ImportLogs. It can be configured via project settings.py:
+```
+IMPORT_LOG_MODEL = 'yourapp.CustomImportLog'
+```
+
+The recommeded way is to create a `CustomImportLog` model that extends abstract model `AbstractBaseLog`.

--- a/djimporter/__init__.py
+++ b/djimporter/__init__.py
@@ -1,6 +1,10 @@
 """
 Package metadata definition.
 """
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
 
 VERSION = (0, 0, 1, 'alpha', 0)
 
@@ -28,3 +32,18 @@ def get_version():
         sub = mapping[VERSION[3]] + str(VERSION[4])
 
     return str(main + sub)
+
+
+def get_importlog_model():
+    """
+    Return the ImportLog model that is active in this project.
+    """
+    importlog_class = getattr(settings, 'IMPORT_LOG_MODEL', 'djimporter.ImportLog')
+    try:
+        return django_apps.get_model(importlog_class, require_ready=False)
+    except ValueError:
+        raise ImproperlyConfigured("IMPORT_LOG_MODEL must be of the form 'app_label.model_name'")
+    except LookupError:
+        raise ImproperlyConfigured(
+            "IMPORT_LOG_MODEL refers to model '%s' that has not been installed" % settings.IMPORT_LOG_MODEL
+        )

--- a/djimporter/apps.py
+++ b/djimporter/apps.py
@@ -1,5 +1,12 @@
 from django.apps import AppConfig
+from django.core import checks
+
+from .checks import check_importlog_model
 
 
 class ImporterConfig(AppConfig):
     name = 'djimporter'
+
+
+    def ready(self):
+        checks.register(check_importlog_model, checks.Tags.models)

--- a/djimporter/checks.py
+++ b/djimporter/checks.py
@@ -1,0 +1,23 @@
+from django.apps import apps
+from django.conf import settings
+
+from . import get_importlog_model
+
+
+def check_importlog_model(app_configs=None, **kwargs):
+    if app_configs is None:
+        importlog_class = getattr(settings, 'IMPORT_LOG_MODEL', 'djimporter.ImportLog')
+        cls = apps.get_model(importlog_class)
+    else:
+        app_label, model_name = settings.IMPORT_LOG_MODEL.split('.')
+        for app_config in app_configs:
+            if app_config.label == app_label:
+                cls = app_config.get_model(model_name)
+                break
+        else:
+            # Checks might be run against a set of app configs that don't
+            # include the specified user model. In this case we simply don't
+            # perform the checks defined below.
+            return []
+
+    return []

--- a/djimporter/tasks.py
+++ b/djimporter/tasks.py
@@ -6,7 +6,9 @@ from django.db.transaction import TransactionManagementError
 from django.db import transaction
 from background_task import background
 
-from .models import ImportLog
+from . import get_importlog_model
+
+ImportLog = get_importlog_model()
 
 
 @background(schedule=0)

--- a/djimporter/views.py
+++ b/djimporter/views.py
@@ -52,7 +52,7 @@ class ImportFormView(FormView):
 
         task_log = ImportLog.objects.create(
             status=ImportLog.CREATED,
-            user=self.request.user,
+            user=str(self.request.user),
             input_file=csv_file.name,
         )
 

--- a/djimporter/views.py
+++ b/djimporter/views.py
@@ -1,9 +1,11 @@
 import os
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import default_storage
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
@@ -41,8 +43,9 @@ class ImportFormView(FormView):
         # store valid form to allow other methods access it
         # e.g. get_importer_context
         self.form = form
-        task_log = self.create_import_task(form.files['upfile'])
-        return redirect('djimporter:importlog-detail', pk=task_log.id)
+        self.task_log = self.create_import_task(form.files['upfile'])
+
+        return HttpResponseRedirect(self.get_success_url())
 
     def create_import_task(self, csv_file):
         importer_class = self.get_importer_class()
@@ -83,3 +86,6 @@ class ImportFormView(FormView):
 
     def get_importer_context(self):
         return {}
+
+    def get_success_url(self):
+        return reverse('djimporter:importlog-detail', pk=self.task_log.id)

--- a/djimporter/views.py
+++ b/djimporter/views.py
@@ -8,9 +8,11 @@ from django.views.generic.detail import DetailView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 
+from . import get_importlog_model
 from .forms import CsvImportForm
-from .models import ImportLog
 from .tasks import run_importer
+
+ImportLog = get_importlog_model()
 
 
 class ListImportsView(ListView):


### PR DESCRIPTION
Add support to use custom user model on a similar way than Django allows to [use a custom user model](https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#specifying-custom-user-model).

Related setting: `IMPORT_LOG_MODEL` (default: `djimporter.ImportLog`)