### PR TITLE
bugfix: get only the name of the file

### DIFF
--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -4,6 +4,7 @@ Define the csv model base classe
 import copy
 import csv
 import io
+import os
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models.base import Model
@@ -334,7 +335,8 @@ class ReadRow(object):
         #   e.g. missing required context
         except (ValidationError, ValueError, KeyError, ObjectDoesNotExist,
             DatabaseError) as error:
-            self.add_error(self.line_number, f.__name__, str(error))
+            file_name = os.path.split(f.__name__)[-1]
+            self.add_error(self.line_number, file_name, str(error))
 
     def pre_save(self):
         if not hasattr(self.Meta, 'pre_save'): return


### PR DESCRIPTION
# Description
In the log model there are a field with max_length=100. When save one error with a name very long this crash.
# Problem
The problem is save all path to the file and the name of the file.
# Solution
I change it for put only in the database the name of the file without the path.