### PR TITLE
bugfix/null time field

### DIFF
--- a/djimporter/fields.py
+++ b/djimporter/fields.py
@@ -106,6 +106,8 @@ class TimeField(Field):
     field_name = "Time"
 
     def to_python(self, value):
+        if hasattr(self, "null") and not value:
+            return None
         field = django_TimeField()
         return field.to_python(value)
 

--- a/djimporter/fields.py
+++ b/djimporter/fields.py
@@ -47,11 +47,8 @@ class Field:
     }
     position = 0
     field_name = "Field"
-    # Are null values allowed?
-    # If null value is allowed, this field could be empty in the row
-    null = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, null=False, **kwargs):
         self.in_csv = kwargs.pop('in_csv', True)
 
         if 'row_num' in kwargs:
@@ -62,14 +59,14 @@ class Field:
         if 'match' in kwargs:
             self.match = kwargs.pop('match')
 
-        if 'null' in kwargs:
-            self.null = kwargs.pop('null')
-
         if 'default' in kwargs:
             # with this value we can overwrite all values in csv
             # for this field. It is usefull when we can a default value
             # but we don't put one default value in the model
             self.has_default = self.to_python(kwargs.pop('default'))
+
+        # If null value is allowed, this field could be empty in the row
+        self.null = null
 
         # Collect default error message from self and parent classes
         error_messages = kwargs.get('error_messages')
@@ -106,7 +103,7 @@ class TimeField(Field):
     field_name = "Time"
 
     def to_python(self, value):
-        if hasattr(self, "null") and not value:
+        if self.null and not value:
             return None
         field = django_TimeField()
         return field.to_python(value)

--- a/tests/test_csvmodels.py
+++ b/tests/test_csvmodels.py
@@ -40,3 +40,13 @@ class DateFieldTest(TestCase):
     def test_unexpected_date_format(self):
         created = fields.DateField()
         self.assertRaises(ValidationError, created.to_python, '19/04/02 07:50')
+
+
+class TimeFieldTest(TestCase):
+    def test_allow_null_values(self):
+        start_time = fields.TimeField(null=True)
+        self.assertIsNone(start_time.to_python(''))
+
+    def test_explicit_disallow_null_values(self):
+        start_time = fields.TimeField(null=False)
+        self.assertRaises(ValidationError, start_time.to_python, '')


### PR DESCRIPTION
# Changes
* Manage null attribute in time fields
# How to test
* Test an importer where a field time has null attribute, now no error is shown
(Example: https://github.com/ico-apps/monitoring/blob/feature/rapis-importers-2/ico_monitoring/importer/csvmodels.py#L566)