### PR TITLE
Bugfix/Show old errors

### DIFF
--- a/djimporter/templates/djimporter/importlog_detail.html
+++ b/djimporter/templates/djimporter/importlog_detail.html
@@ -58,8 +58,17 @@
               <tr>
                 <td class="align-middle">{{ forloop.counter }}</td>
                 <td class="align-middle">{{ error.line }}</td>
-                <td class="align-middle">{{ error.field }}</td>
-                <td>{{ error.message }}</td>
+                {% if error.message %}
+                  <td class="align-middle">{{ error.field }}</td>
+                  <td>{{ error.message }}</td>
+                {% else %}
+                  {% for field, details in error.error.items %}
+                    {% if forloop.first %}
+                      <td class="align-middle">{{ field }}</td>
+                      <td>{{ details }}</td>
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
               </tr>
             {% endfor %}
           </tbody>

--- a/djimporter/templates/djimporter/importlog_detail.html
+++ b/djimporter/templates/djimporter/importlog_detail.html
@@ -62,6 +62,10 @@
                   <td class="align-middle">{{ error.field }}</td>
                   <td>{{ error.message }}</td>
                 {% else %}
+                  {% comment %}
+                    Support showing legacy errors
+                    created by djimporter in versions <= 0.1.0
+                  {% endcomment %}
                   {% for field, details in error.error.items %}
                     {% if forloop.first %}
                       <td class="align-middle">{{ field }}</td>


### PR DESCRIPTION
Fix #39 

# Changes
Show errors created in version <= 0.1.0

# How to test
1. Import data with errors in version 0.1.0
2. Switch to v0.2.0 
3. Check that previous error is shown (with previous format)
4. Import data with errors in version 0.2.0
5. Check that these errors are shown as well (with new format)
