### PR TITLE
Bugfix/43 show all errors importlog

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/djimporter/apps.py
+++ b/djimporter/apps.py
@@ -7,6 +7,5 @@ from .checks import check_importlog_model
 class ImporterConfig(AppConfig):
     name = 'djimporter'
 
-
     def ready(self):
         checks.register(check_importlog_model, checks.Tags.models)

--- a/djimporter/checks.py
+++ b/djimporter/checks.py
@@ -1,18 +1,16 @@
 from django.apps import apps
 from django.conf import settings
 
-from . import get_importlog_model
-
 
 def check_importlog_model(app_configs=None, **kwargs):
     if app_configs is None:
         importlog_class = getattr(settings, 'IMPORT_LOG_MODEL', 'djimporter.ImportLog')
-        cls = apps.get_model(importlog_class)
+        apps.get_model(importlog_class)
     else:
         app_label, model_name = settings.IMPORT_LOG_MODEL.split('.')
         for app_config in app_configs:
             if app_config.label == app_label:
-                cls = app_config.get_model(model_name)
+                app_config.get_model(model_name)
                 break
         else:
             # Checks might be run against a set of app configs that don't

--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -17,6 +17,7 @@ class MetaFieldException(Exception):
     def __init__(self, message):
         Exception.__init__(self, message)
 
+
 class ErrorMixin(object):
     def add_error(self, line_number, field, error):
         if hasattr(error, 'message_dict'):

--- a/djimporter/tasks.py
+++ b/djimporter/tasks.py
@@ -2,8 +2,6 @@ import json
 import os
 
 from django.utils.module_loading import import_string
-from django.db.transaction import TransactionManagementError
-from django.db import transaction
 from background_task import background
 
 from . import get_importlog_model

--- a/djimporter/tasks.py
+++ b/djimporter/tasks.py
@@ -24,19 +24,27 @@ def run_importer(csv_model, csv_filepath, log_id, context={}, delimiter=None, he
     log.save()
 
     # run importer
-    importer = importer_class(
-        csv_filepath, context=context, delimiter=delimiter, headers_mapping=headers_mapping, log=log
-    )
-    importer.is_valid()
-    importer.save()
+    try:
+        importer = importer_class(
+            csv_filepath, context=context, delimiter=delimiter, headers_mapping=headers_mapping, log=log
+        )
+        importer.is_valid()
+        importer.save()
 
-    # update log with import result
-    if importer.errors:
+        # update log with import result
+        if importer.errors:
+            log.status = ImportLog.FAILED
+            log.errors = json.dumps(importer.errors)
+        else:
+            log.status = ImportLog.COMPLETED
+            log.num_rows = len(importer.list_objs)
+
+    except Exception as e:
+        # Not controlled errors will be thrown to log
+        errors = [{'line': 1, 'field': 'Internal Error', 'message': e.args}]
         log.status = ImportLog.FAILED
-        log.errors = json.dumps(importer.errors)
-    else:
-        log.status = ImportLog.COMPLETED
-        log.num_rows = len(importer.list_objs)
+        log.errors = json.dumps(errors)
+
     log.save()
 
     # clean up

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,5 @@
+[flake8]
+max-line-length = 120
+
 [pytest]
 django_find_project = false


### PR DESCRIPTION
Fix #43 

Not controlled errors throws an exception to console and importer process is stuck. User had no feedback.

# Changes
If error is not controlled, add a generic error to importlog and end the importation process.

# How to test
Go to a importer and write down a not controlled dummy error. For instance:

```
diff --git a/pecbms_site_level/importer/csvmodels.py b/pecbms_site_level/importer/csvmodels.py
index e9c37cb..a01fdd7 100644
--- a/pecbms_site_level/importer/csvmodels.py
+++ b/pecbms_site_level/importer/csvmodels.py
@@ -154,6 +154,7 @@ class SingleFileCountsCsv(csvmodels.CsvModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if 'monitoringscheme_code' in self.context:
+            a = MonitoringScheme.objects.get(code='TEST')
             self.Meta.monitoringscheme = get_monitoringscheme_from_context(self.context)
             self.Meta.data_provision = self.log.data_provision
```
Check that this importation process ends and a generic error is shown to the user in import log.