### PR TITLE
Bugfix/Importer guess encoding

### DIFF
--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -8,6 +8,7 @@ import os
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import DatabaseError, transaction
 from django.utils.translation import gettext as _
+from magic import Magic
 
 
 class MetaFieldException(Exception):
@@ -139,7 +140,9 @@ class CsvModel(ErrorMixin):
         return self.dict_error
 
     def open_file(self, path):
-        txt = open(path).read()
+        me = Magic(mime_encoding=True)
+        enc = me.from_file(path)
+        txt = open(path, encoding=enc).read()
         csv = bytes(txt, encoding='utf-8')
         return io.BytesIO(csv)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # TODO license = 'XXX License',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["django>=2.2", "django-background-tasks==1.2.5"],
+    install_requires=["django>=2.2", "django-background-tasks==1.2.5", "python-magic==0.4.24"],
     zip_safe=False,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
# Description
When uploading a file with an encoding differemt og utf-8. importer fails. This PR guess wich encoding is used.

# How to test
- Import a surveys file encoded with ISO-8859 (with accents) and try to import it.
- Go to the survey with accents and check that this character is ok.
- Import a surveys file encoded with UTF-8 (with accents) and try to import it.
- Go to the survey with accents and check that this character is ok.
