### PR TITLE
Allow null values on SlugRelatedField

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -2,9 +2,9 @@ name: Django CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## main
 - [added] #53 Implement CSV guesser to allow dynamic column mapping using JS.
+- [changed] #58 Allow null values on SlugRelatedField.
 - [fixed] #56 Handle too long values of ImportLog.user.
 
 ## [0.4.0] - 2022-07-06

--- a/djimporter/fields.py
+++ b/djimporter/fields.py
@@ -254,7 +254,12 @@ class SlugRelatedField(Field):
         except ObjectDoesNotExist:
             msg = "No match found for %(model)s with value %(value)s"
             params = {'model': self.model.__name__, 'value': value}
-            raise ValidationError(msg, params=params)
+
+            if self.model._meta.get_field(self.match).null:
+                return None
+            else:
+                raise ValidationError(msg, params=params)
+
         except (TypeError, ValueError) as e:
             raise ValidationError(e, code='invalid')
 

--- a/djimporter/fields.py
+++ b/djimporter/fields.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Manager
 from django.db.models import Model as djangoModel
-from django.db.models.query import QuerySet
 from django.db.models import TimeField as django_TimeField
+from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 
 
@@ -247,6 +247,16 @@ class SlugRelatedField(Field):
         if not value:
             if self.null:
                 return None
+
+            # handle if null is defined on model field
+            model_field = self.csv_model._meta.get_field(self.source)
+            if model_field.null:
+                # FIXME this is hacky, any other idea to address that?
+                # monkey patch to avoid csvimporter.validate() raise ValidationError
+                # this field cannot be blank while runnin `object.clean_fields()`
+                model_field.blank = True
+                return None
+
             self.fail('required')
 
         try:
@@ -254,11 +264,7 @@ class SlugRelatedField(Field):
         except ObjectDoesNotExist:
             msg = "No match found for %(model)s with value %(value)s"
             params = {'model': self.model.__name__, 'value': value}
-
-            if self.model._meta.get_field(self.match).null:
-                return None
-            else:
-                raise ValidationError(msg, params=params)
+            raise ValidationError(msg, params=params)
 
         except (TypeError, ValueError) as e:
             raise ValidationError(e, code='invalid')

--- a/tests/data/songs.csv
+++ b/tests/data/songs.csv
@@ -1,0 +1,3 @@
+name;album
+aloja;Lolailo
+single;

--- a/tests/models.py
+++ b/tests/models.py
@@ -32,3 +32,8 @@ class Album(models.Model):
     release_date = models.DateField()
     num_stars = models.IntegerField()
     artist = models.ForeignKey(Musician, on_delete=models.CASCADE)
+
+
+class Song(models.Model):
+    name = models.CharField(max_length=100)
+    album = models.ForeignKey(Album, null=True, on_delete=models.SET_NULL)

--- a/tests/test_csvmodels.py
+++ b/tests/test_csvmodels.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 
 from djimporter import fields, importers
 
-from .models import ForeignKeySource, ForeignKeyTarget, Musician, Album
+from .models import Album, ForeignKeySource, ForeignKeyTarget, Musician, Song
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -53,6 +53,27 @@ class SlugFieldMapping(TestCase):
         importer = ForeignKeySourceCsv(csv_path)
 
         self.assertFalse(importer.is_valid())
+
+
+class NullableSlugFieldTest(TestCase):
+    def test_valid(self):
+        artist = Musician.objects.create(name="Lola", instrument="guitar")
+        Album.objects.create(name="Lolailo", release_date="2023-02-02", num_stars=4, artist=artist)
+        class SongCsv(importers.CsvModel):
+            album = fields.SlugRelatedField(
+                queryset=Album.objects.all(),
+                slug_field='name',
+            )
+
+            class Meta:
+                dbModel = Song
+                fields = ('name', 'album')
+
+
+        csv_path = os.path.join(TESTDATA_DIR, 'songs.csv')
+        importer = SongCsv(csv_path)
+
+        self.assertTrue(importer.is_valid(), importer.errors)
 
 
 class CachedSlugFieldTest(TestCase):


### PR DESCRIPTION
If a SlugRelatedField didn't find an object on the database, it raised ObjectDoesNotExist error and import failed. 
However, model field might be nullable. 

This PR tries to fix this situation. If ObjectDoesNotExist arises but model field has attribute null=True, it will return None instead of a ValidationError. 