### PR TITLE
Add help text option to fields

### DIFF
--- a/djimporter/forms.py
+++ b/djimporter/forms.py
@@ -20,11 +20,16 @@ class UploadDataCsvGuessForm(CsvImportForm):
 
     def __init__(self, *args, **kwargs):
         self.headers = kwargs.pop("headers")
+        self.fields_help_text = kwargs.pop("fields_help_text", {})
         super().__init__(*args, **kwargs)
 
         # Add a field for each expected header
         for header in self.headers:
-            self.fields['header_' + header] = forms.CharField(label=header, widget=forms.Select())
+            self.fields['header_' + header] = forms.CharField(
+                label=header,
+                widget=forms.Select(),
+                help_text=self.fields_help_text.get(header, "")
+            )
 
     def clean_delimiter(self):
         delimiter = self.cleaned_data["delimiter"]

--- a/djimporter/views.py
+++ b/djimporter/views.py
@@ -201,9 +201,12 @@ class ImportFormGuessCsvView(ImportFormView):
         kwargs = super().get_form_kwargs()
 
         headers = self.importer_class.Meta.fields.copy()
+        fields_help_text = getattr(self.importer_class.Meta, 'fields_help_text', {})
         if hasattr(self.importer_class.Meta, 'extra_fields'):
             headers.extend(self.importer_class.Meta.extra_fields)
+
         kwargs.update({
-            'headers': headers
+            'headers': headers,
+            'fields_help_text': fields_help_text,
         })
         return kwargs


### PR DESCRIPTION
Now you can add a fields_help_text dictionary to the csv model to show some extra text, to explain more about the field. 

Example: 

```
class MonitoringSiteEffortCsv(csvmodels.CsvModel):

    site_code = fields.CharField(match='code')
    effort = fields.FloatField()

    class Meta:
        delimiter = ';'
        dbModel = MonitoringSite
        fields = [
            'site_code',
            'effort',
        ]
        fields_help_text = {
            'effort': "Number of points / Transect length (m) / Area sampled (ha)"
        }
```

Now next to the effort field it will also appear this help text