### PR TITLE
Dynamic fields, allow empty object creation, documentation

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, '3.10']
+        python-version: ['3.10.20', '3.12.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -114,6 +114,46 @@ You can create an advanced importer extending ImportFormGuessCsvView (from djimp
       </form>
 
 ```
+### CsvModels definition
+
+You can define an importer extending CsvModel
+
+```
+class MeteoCsv(csvmodels.CsvModel):
+    class Meta:
+        delimiter = ';'
+        dbModel = Meteo
+        fields = ['type', 'value', 'tag', 'label', 'description']
+        extra_fields = ['zone_code']
+        fields_help_text = {
+            'type': "type of the meteo, e.g: rain, temperature"
+        }
+        default_values = {'description': 'Standard meteo'}
+        pre_save = ['set_zone']
+
+        @classmethod
+        def set_zone(cls, readrow):
+            obj = readrow.object
+            zone = ... get zone maybe using readrow.line['zone_code'] ...
+            obj.zone = zone
+```
+- fields: basic model fields that correspond directly to fields on the model.
+- extra_fields: fields that are not part of the model but should be included in the CSV, typically to calculate values or trigger additional logic in pre_save or post_save methods.
+- pre_save/post_save: class methods used to add dynamic logic, such as calculating field values, fetching additional data, or modifying objects before or after they are saved.
+- fields_help_text: use this to define help text for the fields you want to clarify.
+- default_values: when default values are defined, the corresponding fields no longer need to be present in the CSV. The default value will be applied to all imported objects.
+
+### Views
+
+```
+class ImportMeteoView(djimporter_views.ImportFormGuessCsvView):
+    importer_class = importers.MeteoCsv
+    template_name = "core/import_base_csv_guess.html"
+
+    def get_goback_url(self, *args, **kwargs):
+      return reverse_lazy('meteo_list')
+```
+- get_goback_url: optional function, if defined it adds a Go back button to that url.
 
 ## Installation
 Install the package using pip:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ If you want to use the default import log views (list and detail), you should in
 ## Custom import views
 You need to create the import view form template in your project extending your base template. You can create basic importers or advanced importers using field mapper and separator guesser.
 
+```
+class ImportMeteoView(djimporter_views.ImportFormGuessCsvView):
+    importer_class = importers.MeteoCsv
+    template_name = "core/import_base_csv_guess.html"
+
+    def get_goback_url(self, *args, **kwargs):
+      return reverse_lazy('meteo_list')
+```
+- get_goback_url: optional function, if defined it adds a Go back button to that url.
+
 ### Basic importer view
 
 ![simple_importer](https://github.com/ico-apps/django-importer/assets/2751315/fc310978-88ad-41ac-a45a-0992ec232845)
@@ -114,46 +124,6 @@ You can create an advanced importer extending ImportFormGuessCsvView (from djimp
       </form>
 
 ```
-### CsvModels definition
-
-You can define an importer extending CsvModel
-
-```
-class MeteoCsv(csvmodels.CsvModel):
-    class Meta:
-        delimiter = ';'
-        dbModel = Meteo
-        fields = ['type', 'value', 'tag', 'label', 'description']
-        extra_fields = ['zone_code']
-        fields_help_text = {
-            'type': "type of the meteo, e.g: rain, temperature"
-        }
-        default_values = {'description': 'Standard meteo'}
-        pre_save = ['set_zone']
-
-        @classmethod
-        def set_zone(cls, readrow):
-            obj = readrow.object
-            zone = ... get zone maybe using readrow.line['zone_code'] ...
-            obj.zone = zone
-```
-- fields: basic model fields that correspond directly to fields on the model.
-- extra_fields: fields that are not part of the model but should be included in the CSV, typically to calculate values or trigger additional logic in pre_save or post_save methods.
-- pre_save/post_save: class methods used to add dynamic logic, such as calculating field values, fetching additional data, or modifying objects before or after they are saved.
-- fields_help_text: use this to define help text for the fields you want to clarify.
-- default_values: when default values are defined, the corresponding fields no longer need to be present in the CSV. The default value will be applied to all imported objects.
-
-### Views
-
-```
-class ImportMeteoView(djimporter_views.ImportFormGuessCsvView):
-    importer_class = importers.MeteoCsv
-    template_name = "core/import_base_csv_guess.html"
-
-    def get_goback_url(self, *args, **kwargs):
-      return reverse_lazy('meteo_list')
-```
-- get_goback_url: optional function, if defined it adds a Go back button to that url.
 
 ## Installation
 Install the package using pip:

--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -276,7 +276,11 @@ class CsvModel(ErrorMixin, metaclass=CsvModelMetaclass):
 
         try:
             with transaction.atomic():
-                self.dbModel.objects.bulk_create(lines, batch_size=20)
+                if self.dbModel._meta.parents:
+                    for line in lines:
+                        line.save()
+                else:
+                    self.dbModel.objects.bulk_create(lines, batch_size=20)
 
                 if not self.post_save: return
                 for row in self.list_objs:

--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -412,7 +412,8 @@ class ReadRow(ErrorMixin):
         self.data = data
 
     def create_model(self):
-        if not self.data and len(self.fields)>0: return
+        if self.data is None or (self.data == {} and len(self.fields) > 0):
+            return
         self.object = self.Meta.dbModel(**self.data)
 
     def validate(self):

--- a/djimporter/importers.py
+++ b/djimporter/importers.py
@@ -412,7 +412,7 @@ class ReadRow(ErrorMixin):
         self.data = data
 
     def create_model(self):
-        if not self.data: return
+        if not self.data and len(self.fields)>0: return
         self.object = self.Meta.dbModel(**self.data)
 
     def validate(self):

--- a/djimporter/views.py
+++ b/djimporter/views.py
@@ -217,11 +217,11 @@ class ImportFormGuessCsvView(ImportFormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
 
-        headers = self.importer_class.Meta.fields.copy()
-        fields_help_text = getattr(self.importer_class.Meta, 'fields_help_text', {})
-        default_values = getattr(self.importer_class.Meta, 'default_values', {})
-        if hasattr(self.importer_class.Meta, 'extra_fields'):
-            headers.extend(self.importer_class.Meta.extra_fields)
+        importer_class = self.get_importer_class()
+        importer = importer_class('', context = self.get_importer_context())
+        headers = importer.get_user_visible_fields()
+        fields_help_text = getattr(importer_class.Meta, 'fields_help_text', {})
+        default_values = getattr(importer_class.Meta, 'default_values', {})
 
         kwargs.update({
             'headers': headers,

--- a/docs/csvmodels.md
+++ b/docs/csvmodels.md
@@ -72,6 +72,22 @@ This indicates that the name that should appear in the file is the same as the o
 
 The next point to highlight is that we have not defined anything for **last_name**, it only appears in the fields list. If the csv column name and the model name is the same, we do not need to define anything else. We want to warn that if a model field is not defined in the **fields** variable, then it will take what appears in the **default** variable that we have described in our model.
 
+## More options (Help text, default values)
+
+- fields_help_text: use this to define help text for the fields you want to clarify.
+- default_values: when default values are defined, the corresponding fields no longer need to be present in the CSV. The default value will be applied to all imported objects.
+
+```
+class MeteoCsv(csvmodels.CsvModel):
+    class Meta:
+        delimiter = ';'
+        dbModel = Meteo
+        fields = ['type', 'value', 'tag', 'label', 'description']
+        fields_help_text = {
+            'type': "type of the meteo, e.g: rain, temperature"
+        }
+        default_values = {'description': 'Standard meteo'}
+```
 
 ## Simple mapping with a ForeingKey
 A simple mapping with a ForeingKey requires that the object to which we are going to relate using the ForeingKey already exists.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,9 @@ To install the django-importer, follow the steps described on the [installation]
 
 * [CsvModel](csvmodels.md)
   - [Simple Mapping](csvmodels.md#simple-mapping)
+  - [More options (Help text, default values)](csvmodels.md#more-options-help-text-default-values)
   - [Simple Mapping with ForeingKey](csvmodels.md#simple-mapping-with-a-foreingkey)
-  - [FoeringKey with more than one column](csvmodels.md#foreingkey-con-m%C3%A1s-de-una-columna)
+  - [ForeingKey with more than one column](csvmodels.md#foreingkey-con-m%C3%A1s-de-una-columna)
   - [Pre_save and Post_save](csvmodels.md#pre_save-and-post_save)
   - [One csv and two models](csvmodels.md#one-csv-two-models)
   - [Specials Fields](csvmodels.md#specials-fields)


### PR DESCRIPTION
- Allow empty objects creation (importer with non direct fields, it may have extra_fields, ...)
- Importer UI showing all fields, including the ones added dynamically
- Don't do bulk create if dbmodel has a non abstract parent. Create it line by line instead